### PR TITLE
Implement io.Reader, io.Writer for quote database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,13 @@
-# The base go-image
-FROM golang:1.21-alpine
+# Builder image
+FROM golang:1.21-alpine as build
 
 RUN mkdir /app 
 COPY . /app
-
 WORKDIR /app
+RUN go build
 
-RUN go build -v
+# Server image
+FROM gcr.io/distroless/static-debian12
 
-# Run the server executable
+COPY --from=build /app/boyd_cooper /app/boyd_cooper
 CMD [ "/app/boyd_cooper" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,10 +4,11 @@ FROM golang:1.21-alpine as build
 RUN mkdir /app 
 COPY . /app
 WORKDIR /app
-RUN go build
+RUN go build -v
 
 # Server image
 FROM gcr.io/distroless/static-debian12
 
 COPY --from=build /app/boyd_cooper /app/boyd_cooper
+WORKDIR /app
 CMD [ "/app/boyd_cooper" ]

--- a/commands.go
+++ b/commands.go
@@ -125,7 +125,7 @@ var handlers = map[string]func(*discordgo.Session, *discordgo.InteractionCreate)
 			return
 		}
 
-		err := writeQuote(quote)
+		err := writeQuote(quoteFile, quote)
 		if err != nil {
 			sendError(s, d, err)
 			return

--- a/main.go
+++ b/main.go
@@ -9,6 +9,8 @@ import (
 	"github.com/joho/godotenv"
 )
 
+var quoteFile *os.File
+
 func main() {
 	log.Println("Starting BoydBot...")
 	if err := godotenv.Load(); err != nil {
@@ -30,13 +32,16 @@ func main() {
 	}
 
 	// open the quotes file
-	quoteFile, err = os.OpenFile("quotes.txt", os.O_RDWR|os.O_APPEND|os.O_CREATE, 0644)
+	quoteFile, err := os.OpenFile("quotes.txt", os.O_RDWR|os.O_APPEND|os.O_CREATE, 0644)
 	if err != nil {
 		panic(err)
 	}
+	defer quoteFile.Close()
 
 	// Load the quotes
-	loadQuotes()
+	log.Println("Loading quotes...")
+	loadQuotes(quoteFile)
+	log.Println("Loaded", len(quoteList), "quotes")
 
 	// Index quotes
 	indexQuotes()

--- a/quotes.go
+++ b/quotes.go
@@ -2,27 +2,23 @@ package main
 
 import (
 	"bufio"
-	"log"
-	"os"
+	"io"
 )
 
 var quoteList []string
-var quoteFile *os.File
 
-// Loads the quote list from a file
-func loadQuotes() {
-	log.Println("Loading quotes...")
+// Loads the quote list from an input stream
+func loadQuotes(input io.Reader) {
 	quoteList = make([]string, 0)
 
-	scanner := bufio.NewScanner(bufio.NewReader(quoteFile))
+	scanner := bufio.NewScanner(bufio.NewReader(input))
 	for scanner.Scan() {
 		quoteList = append(quoteList, scanner.Text())
 	}
-	log.Println("Loaded", len(quoteList), "quotes")
 }
 
-// Saves a quote to the database
-func writeQuote(quote string) error {
-	_, err := quoteFile.WriteString(quote + "\n")
+// Writes a quote to an output stream
+func writeQuote(output io.Writer, quote string) error {
+	_, err := output.Write([]byte(quote + "\n"))
 	return err
 }

--- a/theory.go
+++ b/theory.go
@@ -23,21 +23,13 @@ func buildSentence(asideChance uint32, interjectionChance uint32) string {
 	aside := [2]string{"Visiting hours are over!", "Why does that hydrant keep looking at me?"}
 	interjection := [15]string{"*chuckles*", "(Ho ho!)", "(Wait...)", "(Uh...)", "(Um...)", "*cough*", "(Uh...)", "(Hmm...)", "(Ha!)", "(Yeah, yeah, yeah...)", "(What?)", "(No, no, nonono...)", "(Okay, okay but...)", "(Huh?)", "(Oh-hoh, RIGHT...)"}
 
-	sentence := ""
 	if randGen.Uint32()%asideChance == 0 {
-		sentence = aside[rand.Uint32()%2]
-		return sentence
-	}
-	if randGen.Uint32()%interjectionChance == 0 {
-		sentence = interjection[rand.Uint32()%15]
-		return sentence
-	}
-
-	if randGen.Int()%2 == 0 {
-		sentence = subjects[rand.Int()%40] + " " + transitiveVerb[rand.Int()%12] + " " + object[rand.Int()%17] + " " + conclution[rand.Int()%9]
+		return aside[rand.Uint32()%2]
+	} else if randGen.Uint32()%interjectionChance == 0 {
+		return interjection[rand.Uint32()%15]
+	} else if randGen.Int()%2 == 0 {
+		return subjects[rand.Int()%40] + " " + transitiveVerb[rand.Int()%12] + " " + object[rand.Int()%17] + " " + conclution[rand.Int()%9]
 	} else {
-		sentence = subjects[rand.Uint32()%40] + " " + subjectConnector[rand.Uint32()%8] + " " + subjects[rand.Uint32()%39] + " " + intransitiveVerb[rand.Uint32()%17] + " " + preposition[rand.Uint32()%7] + " " + object[rand.Uint32()%17]
+		return subjects[rand.Uint32()%40] + " " + subjectConnector[rand.Uint32()%8] + " " + subjects[rand.Uint32()%39] + " " + intransitiveVerb[rand.Uint32()%17] + " " + preposition[rand.Uint32()%7] + " " + object[rand.Uint32()%17]
 	}
-
-	return sentence
 }


### PR DESCRIPTION
Refactored `quoteFile` into an `io.Reader` and `io.Writer` interface at the `quotes.go` level. Additionally, the logic in `theory.go` was simplified to reduce allocations by eliminating the variable `sentence`. A multi-stage Dockerfile was also introduced, resulting in a final stage image that is ~8% of its original size.

Two notes regarding the Dockerfile:
- if any CGO-requiring dependency is introduced, the image `gcr.io/distroless/static-debian12` should be switched to `gcr.io/distroless/base-debian12` so that the image includes the appropriate glibc shared objects
- if spatial optimization is of utmost concern, `go build` may be switched to `go build -ldflags="-s -w"` in order to strip the DWARF tables and symbol table. This will result in a smaller binary at the cost of being able to debug the binary with `gdb` or `delve`

